### PR TITLE
ApproveするときにもLGTMボタンを使いたい

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,11 @@
   min-height: 45px;
 }
 
+#lgtm_wrapper_submit {
+  margin: 15px 8px;
+  min-height: 45px;
+}
+
 .lgtm_icon_wrapper {
   float: left;
   width: 44px;
@@ -52,6 +57,15 @@
   margin-left: 2px;
   border-width: 7px;
   border-right-color: #fff;
+}
+
+#lgtm_box_submit {
+  border: 1px solid #7ae2a8;
+  min-height: 45px;
+  border-radius: 3px;
+  padding: 15px;
+  position: relative;
+  text-align: center;
 }
 
 #lgtm_button {

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -13,7 +13,7 @@ class Frontend {
 
     this.urlPatterns = new Map([
       ["partial-pull-merging", /pull\/\d+(?:$|#)/],
-      ["submit-review", /pull\/\d+\/files(?:$|#)/],
+      ["submit-review", /pull\/\d+\/(commits|files)/],
     ]);
   }
 
@@ -40,7 +40,7 @@ class Frontend {
     this.observer = new MutationObserver((changedNodes) => {
       let target = this.getTarget();
 
-      if (target != null && $("#" + target).length) {
+      if (target != null && $("#" + target).length > 0) {
         this.createLgtmButton(target);
       }
     });

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -13,7 +13,7 @@ class Frontend {
 
     this.urlPatterns = new Map([
       ["partial-pull-merging", /pull\/\d+(?:$|#)/],
-      ["submit-review", /pull\/\d+\/(commits|files)/],
+      ["submit-review", /pull\/\d+\/(?:commits|files)/],
     ]);
   }
 
@@ -40,7 +40,7 @@ class Frontend {
     this.observer = new MutationObserver((changedNodes) => {
       let target = this.getTarget();
 
-      if (target != null && $("#" + target).length > 0) {
+      if (target != null) {
         this.createLgtmButton(target);
       }
     });
@@ -71,7 +71,7 @@ class Frontend {
    * @param  {string|null} target
    */
   createLgtmButton(target) {
-    if (target == null) {
+    if (target == null || $("#" + target).length == 0) {
       return;
     }
 
@@ -80,28 +80,28 @@ class Frontend {
       this.lgtmButtons.delete(target);
     }
 
-    let lgtmButton = null;
+    let options = null;
     switch (target) {
       case "partial-pull-merging":
-        lgtmButton = new LgtmButton(this.app, {
+        options = {
           target: "#" + target,
           methodType: this.app.templater.METHOD_TYPE_AFTER,
           template: "lgtmButton",
           inputTarget: "#new_comment_field",
-        });
+        };
         break;
 
       case "submit-review":
-        lgtmButton = new LgtmButton(this.app, {
+        options = {
           target: "#" + target + " .write-content",
           methodType: this.app.templater.METHOD_TYPE_AFTER,
           template: "lgtmButtonSubmit",
           inputTarget: "#pull_request_review_body",
-        });
+        };
         break;
     }
 
-    lgtmButton.create();
-    this.lgtmButtons.set(target, lgtmButton);
+    this.lgtmButtons.set(target, new LgtmButton(this.app, options));
+    this.lgtmButtons.get(target).create();
   }
 }

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -9,12 +9,12 @@ class Frontend {
     this.app = app;
 
     this.observer = null;
-    this.lgtmButton = null;
+    this.lgtmButtons = new Map();
 
-    this.urlPatterns = {
-      "partial-pull-merging": /pull\/\d+(?:$|#)/,
-      "submit-review": /pull\/\d+\/files(?:$|#)/,
-    };
+    this.urlPatterns = new Map([
+      ["partial-pull-merging", /pull\/\d+(?:$|#)/],
+      ["submit-review", /pull\/\d+\/files(?:$|#)/],
+    ]);
   }
 
   /**
@@ -56,7 +56,7 @@ class Frontend {
   getTarget() {
     let target = null;
 
-    $.each(this.urlPatterns, (key, pattern) => {
+    this.urlPatterns.forEach((pattern, key) => {
       if (window.location.href.match(pattern)) {
         target = key;
       }
@@ -75,13 +75,15 @@ class Frontend {
       return;
     }
 
-    if (this.lgtmButton != null) {
-      this.lgtmButton.destroy();
+    if (this.lgtmButtons.has(target)) {
+      this.lgtmButtons.get(target).destroy();
+      this.lgtmButtons.delete(target);
     }
 
+    let lgtmButton = null;
     switch (target) {
       case "partial-pull-merging":
-        this.lgtmButton = new LgtmButton(this.app, {
+        lgtmButton = new LgtmButton(this.app, {
           target: "#" + target,
           methodType: this.app.templater.METHOD_TYPE_AFTER,
           template: "lgtmButton",
@@ -90,7 +92,7 @@ class Frontend {
         break;
 
       case "submit-review":
-        this.lgtmButton = new LgtmButton(this.app, {
+        lgtmButton = new LgtmButton(this.app, {
           target: "#" + target + " .write-content",
           methodType: this.app.templater.METHOD_TYPE_AFTER,
           template: "lgtmButtonSubmit",
@@ -99,6 +101,7 @@ class Frontend {
         break;
     }
 
-    this.lgtmButton.create();
+    lgtmButton.create();
+    this.lgtmButtons.set(target, lgtmButton);
   }
 }

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -23,7 +23,7 @@ class Frontend {
   initialize() {
     this.startObservation();
 
-    this.createLgtmButton(this.getTarget());
+    this._createLgtmButton(this._getTarget());
   }
 
   /**
@@ -38,10 +38,10 @@ class Frontend {
     }
 
     this.observer = new MutationObserver((changedNodes) => {
-      let target = this.getTarget();
+      let target = this._getTarget();
 
       if (target != null) {
-        this.createLgtmButton(target);
+        this._createLgtmButton(target);
       }
     });
 
@@ -53,7 +53,7 @@ class Frontend {
    * 対象でない URL の場合は null を返す。
    * @return {string|null}
    */
-  getTarget() {
+  _getTarget() {
     let target = null;
 
     this.urlPatterns.forEach((pattern, key) => {
@@ -70,7 +70,7 @@ class Frontend {
    * 対象が無い場合はスキップする。
    * @param  {string|null} target
    */
-  createLgtmButton(target) {
+  _createLgtmButton(target) {
     if (target == null || $("#" + target).length == 0) {
       return;
     }

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -56,7 +56,7 @@ class Frontend {
   getTarget() {
     let target = null;
 
-    $.each(this.urlPatterns, function (key, pattern) {
+    $.each(this.urlPatterns, (key, pattern) => {
       if (window.location.href.match(pattern)) {
         target = key;
       }

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -23,7 +23,7 @@ class Frontend {
   initialize() {
     this.startObservation();
 
-    this._createLgtmButton(this._getTarget());
+    this.createLgtmButton_(this.getTarget_());
   }
 
   /**
@@ -38,10 +38,10 @@ class Frontend {
     }
 
     this.observer = new MutationObserver((changedNodes) => {
-      let target = this._getTarget();
+      let target = this.getTarget_();
 
       if (target != null) {
-        this._createLgtmButton(target);
+        this.createLgtmButton_(target);
       }
     });
 
@@ -53,7 +53,7 @@ class Frontend {
    * 対象でない URL の場合は null を返す。
    * @return {string|null}
    */
-  _getTarget() {
+  getTarget_() {
     let target = null;
 
     this.urlPatterns.forEach((pattern, key) => {
@@ -70,7 +70,7 @@ class Frontend {
    * 対象が無い場合はスキップする。
    * @param  {string|null} target
    */
-  _createLgtmButton(target) {
+  createLgtmButton_(target) {
     if (target == null || $("#" + target).length == 0) {
       return;
     }

--- a/js/frontend/Frontend.js
+++ b/js/frontend/Frontend.js
@@ -13,6 +13,7 @@ class Frontend {
 
     this.urlPatterns = {
       "partial-pull-merging": /pull\/\d+(?:$|#)/,
+      "submit-review": /pull\/\d+\/files(?:$|#)/,
     };
   }
 
@@ -85,6 +86,15 @@ class Frontend {
           methodType: this.app.templater.METHOD_TYPE_AFTER,
           template: "lgtmButton",
           inputTarget: "#new_comment_field",
+        });
+        break;
+
+      case "submit-review":
+        this.lgtmButton = new LgtmButton(this.app, {
+          target: "#" + target + " .write-content",
+          methodType: this.app.templater.METHOD_TYPE_AFTER,
+          template: "lgtmButtonSubmit",
+          inputTarget: "#pull_request_review_body",
         });
         break;
     }

--- a/js/frontend/LgtmButton.js
+++ b/js/frontend/LgtmButton.js
@@ -4,11 +4,13 @@ class LgtmButton {
    *
    * @constructor
    * @param {array} app
+   * @param {array} options
    */
-  constructor(app) {
+  constructor(app, options) {
     this.REQUEST_IMAGES_COUNT = 2;
 
     this.app = app;
+    this.options = options;
     this.isLoading = false;
   }
 
@@ -16,25 +18,25 @@ class LgtmButton {
    * ボタンを作成して、配置する。
    */
   create() {
-    let target = "#partial-pull-merging";
-    if ($(target).length === 0) {
+    if ($(this.options.target).length === 0) {
       return;
     }
 
-    this.destroy();
-    this.app.templater.render(
-      "lgtmButton",
-      target,
-      this.app.templater.METHOD_TYPE_AFTER,
+    this.app.templater.insert(
+      this.options.template,
+      this.options.target,
+      this.options.methodType,
       this.getVueData_()
-    );
+    ).then(vue => {
+      this.vue = vue;
+    });
   }
 
   /**
    * ボタンを削除する。
    */
   destroy() {
-    $("#lgtm_wrapper").remove();
+    $(this.vue.$el).remove();
   }
 
   /**
@@ -44,7 +46,6 @@ class LgtmButton {
    */
   getVueData_() {
     return {
-      el: "#lgtm_wrapper",
       data: {
         src: this.getIconUrl_()
       },
@@ -56,17 +57,17 @@ class LgtmButton {
           this.isLoading = true;
           this.requestImages_().then((images) => {
             for (let image of images) {
-              let lgtmImage = new LgtmImage(this.app, image);
+              let lgtmImage = new LgtmImage(this.app, image, this.options.inputTarget);
               lgtmImage.create();
             }
             this.isLoading = false;
           });
         },
-        onMouseenter: () => {
-          $(".lgtm_not_initial").animate({"opacity": 0.1}, 100);
+        onMouseenter: (event) => {
+          $(event.target).find(".lgtm_not_initial").animate({"opacity": 0.1}, 100);
         },
-        onMouseleave: () => {
-          $(".lgtm_not_initial").animate({"opacity": 1}, 100);
+        onMouseleave: (event) => {
+          $(event.target).find(".lgtm_not_initial").animate({"opacity": 1}, 100);
         }
       }
     }

--- a/js/frontend/LgtmButton.js
+++ b/js/frontend/LgtmButton.js
@@ -36,7 +36,7 @@ class LgtmButton {
    * ボタンを削除する。
    */
   destroy() {
-    $(this.vue.$el).remove();
+    $(`#${this.vue.$el.id}`).remove();
   }
 
   /**

--- a/js/frontend/LgtmImage.js
+++ b/js/frontend/LgtmImage.js
@@ -5,11 +5,12 @@ class LgtmImage {
    * @constructor
    * @param {array}  app
    * @param {object} data - 画像に関するデータ
+   * @param {string} inputTarget - 画像を挿入する対象
    */
-  constructor(app, data) {
+  constructor(app, data, inputTarget) {
     this.app = app;
-
     this.data = data;
+    this.inputTarget = inputTarget;
     this.vue = null;
   }
 
@@ -67,6 +68,7 @@ class LgtmImage {
    */
   input_() {
     let text = `\n\n![LGTM](${this.data.imageUrl})`;
-    $("#new_comment_field").val($('#new_comment_field').val() + text);
+    let $target = $(this.inputTarget);
+    $target.val($target.val() + text);
   }
 }

--- a/js/frontend/Templater.js
+++ b/js/frontend/Templater.js
@@ -58,6 +58,9 @@ class Templater {
           case this.METHOD_TYPE_PREPEND:
             $dom = $(content).prependTo(target);
             break;
+          case this.METHOD_TYPE_AFTER:
+            $dom = $(content).insertAfter(target);
+            break;
         }
 
         let id = this.PREFIX_DOM_ID_NAME + this.app.utilities.unique();

--- a/templates/lgtmButton.html
+++ b/templates/lgtmButton.html
@@ -1,14 +1,16 @@
-<div id="lgtm_wrapper">
-  <span class="lgtm_icon_wrapper">
-    <img class="lgtm_icon" alt="your avatar" v-bind:src="src">
-  </span>
-  <div id="lgtm_box">
-    <button id="lgtm_button" v-on:click="onClick" v-on:mouseenter="onMouseenter" v-on:mouseleave="onMouseleave">
-      <span class="lgtm_initial">L</span><span class="lgtm_not_initial">ooks</span>
-      <span class="lgtm_initial">G</span><span class="lgtm_not_initial">ood</span>
-      <span class="lgtm_initial">T</span><span class="lgtm_not_initial">o</span>
-      <span class="lgtm_initial">M</span><span class="lgtm_not_initial">e!</span>
-    </button>
-    <div class="lgtm_images_wrapper"></div>
+<div>
+  <div id="lgtm_wrapper">
+    <span class="lgtm_icon_wrapper">
+      <img class="lgtm_icon" alt="your avatar" v-bind:src="src">
+    </span>
+    <div id="lgtm_box">
+      <button id="lgtm_button" type="button" v-on:click="onClick" v-on:mouseenter="onMouseenter" v-on:mouseleave="onMouseleave">
+        <span class="lgtm_initial">L</span><span class="lgtm_not_initial">ooks</span>
+        <span class="lgtm_initial">G</span><span class="lgtm_not_initial">ood</span>
+        <span class="lgtm_initial">T</span><span class="lgtm_not_initial">o</span>
+        <span class="lgtm_initial">M</span><span class="lgtm_not_initial">e!</span>
+      </button>
+      <div class="lgtm_images_wrapper"></div>
+    </div>
   </div>
 </div>

--- a/templates/lgtmButtonSubmit.html
+++ b/templates/lgtmButtonSubmit.html
@@ -1,0 +1,13 @@
+<div>
+  <div id="lgtm_wrapper_submit">
+    <div id="lgtm_box_submit">
+      <button id="lgtm_button" type="button" v-on:click="onClick" v-on:mouseenter="onMouseenter" v-on:mouseleave="onMouseleave">
+        <span class="lgtm_initial">L</span><span class="lgtm_not_initial">ooks</span>
+        <span class="lgtm_initial">G</span><span class="lgtm_not_initial">ood</span>
+        <span class="lgtm_initial">T</span><span class="lgtm_not_initial">o</span>
+        <span class="lgtm_initial">M</span><span class="lgtm_not_initial">e!</span>
+      </button>
+      <div class="lgtm_images_wrapper"></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 経緯
EASY LGTM ボタンが制作されて以降、 GitHub に仕様変更で、レビュアー機能が追加されました。
それを機に、 GitHub のレビュー文化は Approved を使用したものに遷移しましたが、 EASY LGTM では対応しておらず、 Approved と LGTM コメントを分けなければならないツラミが生まれてしまいました。

## 目的
本 PR では、上記の経緯から不便になってしまった EASY LGTM をより便利にするため、 Approved する項目の近くにも LGTM ボタンを出し、使えるようにしたいので、その実装を行いました。

## 実装内容
- コメント欄下に LGTM ボタンを設置するよう最適化されていたので、複数箇所にボタンが設置できるように汎用化した実装に変更しました
- Approved するときに使用する Review changed の枠内に LGTM ボタンを設置しました

## gif
![capture](https://user-images.githubusercontent.com/12483929/28096235-33d33e7e-66e2-11e7-831d-6f58718ffdd0.gif)

## 備考
既存のコメント欄下にある LGTM ボタンの挙動に変更はありません。
js のお作法が分からないので、間違いを犯していたら教えてください。
