### PR TITLE
ダークモードに対応

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -77,35 +77,42 @@
 }
 
 #lgtm_button {
-  background-color: white;
+  background-color: var(--color-bg-primary);
   border: none;
   font-size: 20px;
   height: 45px;
   width: 100%;
+  color: var(--color-text-primary);
 }
 
 #lgtm_button_close {
   background-color: tomato;
   border: none;
-  box-shadow: white 0px 0px 0px 12px inset;
-  color: white;
+  box-shadow: var(--color-bg-primary) 0px 0px 0px 12px inset;
+  color: var(--color-bg-primary);
   height: 25px;
   width: 100%;
   display: none;
   transition: box-shadow 0.1s linear;
+  border-radius: 3px;
 }
 
 #lgtm_button_close:hover {
-  box-shadow: white 0px 0px 0px 0px inset;
+  box-shadow: var(--color-bg-primary) 0px 0px 0px 0px inset;
 }
 
 .lgtm_image {
   width: 330px;
-  padding: 2px;
-  border: 3px solid white;
+  border: 3px solid var(--color-bg-primary);
   border-radius: 4px;
   margin-top: 5px;
   cursor: pointer;
+  transition: border-color 0.1s linear;
+  background-color: white;
+}
+
+.lgtm_image:hover {
+  border-color: #34d058;
 }
 
 #hint {

--- a/js/frontend/LgtmImage.js
+++ b/js/frontend/LgtmImage.js
@@ -50,12 +50,6 @@ class LgtmImage {
           $("#lgtm_button_close").hide(120);
           $("input[value='approve']").click();
         },
-        onMouseenter: () => {
-          $(this.vue.$el).animate({"borderColor": "#34d058"}, 100);
-        },
-        onMouseleave: () => {
-          $(this.vue.$el).animate({"borderColor": "white"}, 100);
-        }
       }
     };
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "EASY LGTM",
   "description": "LGTMを手軽に",
-  "version": "2.1",
+  "version": "2.2",
   "manifest_version": 2,
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
GitHub公式の「Theme preferences」に対応する。
（非公式のダークモード対応には非対応）

どのThemeにしても違和感が無いよう、背景色や文字色は可変とする。

## スクリーンショット
### Default light

<img src="https://user-images.githubusercontent.com/18714698/114349820-57cd9f00-9ba3-11eb-9f15-69e9ad0e5c45.jpg" alt="スクリーンショット 2021-04-12 15 25 07" width="320">

### Default Dark

<img src="https://user-images.githubusercontent.com/18714698/114349824-58fecc00-9ba3-11eb-9248-641317cc3a10.jpg" alt="スクリーンショット 2021-04-12 15 24 44" width="320">

### Dark dimmed

<img src="https://user-images.githubusercontent.com/18714698/114349810-556b4500-9ba3-11eb-9d13-daf0680be886.jpg" alt="スクリーンショット 2021-04-12 15 25 22" width="320">
